### PR TITLE
Connect register and authentication logic

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -10,3 +10,5 @@ token:
 server:
   domain: SERVER_DOMAIN
   port: SERVER_PORT
+mail:
+  send: SERVER_SEND_MAIL

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,7 +2,7 @@ couch:
   protocol: http
   domain: localhost
   port: 5984
-  username: admin # Override these if your development CouchDB is different
+  username: admin
   password: admin
 token:
   secret: secret
@@ -13,3 +13,4 @@ server:
   port: 8080
 mail:
   account: bicycle-touring-companion@adventurecycling.org
+  send: false

--- a/config/production.yml
+++ b/config/production.yml
@@ -2,9 +2,14 @@ couch:
   protocol: http
   domain: opsworks-database-1500749100.us-east-1.elb.amazonaws.com
   port: 5984
+  # username: env SERVER_COUCH_USERNAME
+  # password: env SERVER_COUCH_PASSWORD
 token:
+  # secret: env SERVER_SECRET
   iss: adventurecycling.org
   exp: 15m
 server:
   domain: localhost
   port: 80
+mail:
+  send: true

--- a/config/test.yml
+++ b/config/test.yml
@@ -1,0 +1,2 @@
+mail:
+  send: true

--- a/es6/src/authenticate.js
+++ b/es6/src/authenticate.js
@@ -31,19 +31,21 @@ const expiresIn = config.get( 'token.exp' );
 const algorithm = 'HS256';
 
 // Passport strategy to determine if a token-holder is a moderator.
-export const strategy = new JwtStrategy( {
-  issuer,
-  algorithms: [ algorithm ],
-  secretOrKey: secret,
-  authScheme: 'JWT'
-},
+export const strategy = new JwtStrategy(
+  {
+    issuer,
+    algorithms: [ algorithm ],
+    secretOrKey: secret,
+    authScheme: 'JWT'
+  },
   ( jwt_payload, done ) => {
     if ( contains( jwt_payload.roles, 'moderator' ) ) {
       done( null, jwt_payload );
     } else {
       done( 'you are not a moderator', false );
     }
-  } );
+  }
+);
 
 // Sign a token with our server's secret. The token's payload will contain
 // the user's email and assigned roles.
@@ -70,7 +72,7 @@ export default function authenticate( req, res ) {
   nano_db.auth( email, password, ( err, body, headers ) => {
     if ( err ) {
       return res.status( 400 ).json( {
-        unauthorized: 'either your email, password , or both are incorrect'
+        unauthorized: 'either your email, password, or both are incorrect'
       } );
     } else {
       return res.status( 200 ).json( {

--- a/es6/src/model/base.js
+++ b/es6/src/model/base.js
@@ -7,18 +7,18 @@
  * it under the terms of the Affero GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * btc-app-server is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * Affero GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the Affero GNU General Public License
  * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Model } from 'backbone';
-import { omit, union, isArray } from 'underscore';
+import { Model, Collection } from 'backbone';
+import { omit, union, isArray, intersection, keys, extend } from 'underscore';
 
 // Special keys that are reserved by serialized CouchDB documents
 const baseSafeguard = [ '_id', '_rev' ];
@@ -26,7 +26,7 @@ const baseSafeguard = [ '_id', '_rev' ];
 // ## Couch Model
 // This base class ensures the client will not unknowingly modify the special
 // keys of a CouchDB document.
-export default Model.extend( {
+export const CouchModel = Model.extend( {
 
   // By default, `CouchModel` safeguards `_id` and `_rev`. You can extend
   // this list of safeguarded keys by passing an array in `options.special`.
@@ -38,6 +38,13 @@ export default Model.extend( {
     } else {
       this.safeguard = baseSafeguard;
     }
+  },
+
+  // When fetching a single document, allow overriding safeguarded Couch keys
+  fetch: function( options ) {
+    return Model.prototype.fetch.call( this, extend( {}, options, {
+      force: true
+    } ) );
   },
 
   // Override Backbone's set function to ignore all the special keys, *unless
@@ -59,12 +66,30 @@ export default Model.extend( {
 
     if ( !options.force ) {
       // Uncomment to log keys that we omit from super.set()
-      /* const omitted = intersection( keys( attrs ), this.safeguard ); */
+      const omitted = intersection( keys( attrs ), this.safeguard );
 
       // Actually omit safeguarded keys
       attrs = omit( attrs, this.safeguard );
+
+      if ( omitted.length > 0 ) {
+        throw new Error( 'attempted override of safeguarded keys: ' +
+          omitted.toString() );
+      }
     }
 
     return Model.prototype.set.call( this, attrs, options );
+  }
+} );
+
+// ## Couch Collection
+// This base collection class helps the CouchModel to prevent the client
+// from unknowingly modifying the special keys of a CouchDB document.
+export const CouchCollection = Collection.extend( {
+
+  // When fetching multiple documents, allow overriding safeguarded Couch keys
+  fetch: function( options ) {
+    return Collection.prototype.fetch.call( this, extend( {}, options, {
+      force: true
+    } ) );
   }
 } );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btc-app-server",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "description": "Node Server",
   "main": "es5/src/index.js",
   "dependencies": {


### PR DESCRIPTION
Fixes _users document overwrite issue.

Before, we were 'patching' documents into PouchDB, which PouchDB does not support. On document update, you have to supply the document exactly as you want it to look. This was deleting the user's password hash.
